### PR TITLE
Add support for mulitple DES keys for different versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ writes JFFS2 image into ``/dev/mtdblock0`` device and mounts it:
     Filesystem      Size  Used Avail Use% Mounted on
     /dev/mtdblock0   16M  3.5M   13M  22% /mnt/fw_app
 
+If you want to mount the filesystem to another directory than /mnt/fw_app
+use the ``-t <mount-dir>`` parameter to override.
+
 *Please note*: this command requires root privileges on Linux.
 
 ## Pack and sign 'npcupg' firmware from JFFS2 image

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ firmware version, UNIX timestamp of the image and some supplementary attributes.
 
 ## Verify signature of the 'npcupg' firmware
 
-At this moment ``gm_app_fw.py`` contains DES key to check signature of FW version 14.
+At this moment ``gm_app_fw.py`` contains some DES key to check signature of FW. Following
+versions are currently supported:
+  * Version 13.x.x.x
+  * Version 14.x.x.x
+  * Version 22.x.x.x
 
     $ ./gm_app_fw.py -f ../npcupg_14.00.00.75.bin -v
     fw_ver : 14.00.00.75

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ FW ver 19 contains "APP" image at offset 0x40000
     sig ok : False
 
 
-Also it recognized header of FW version 13, 19, 21 but can't verify the
+Also it recognized header of FW version 19, 21 but can't verify the
 signature nor pack and sign modified JFFS2 image.
 
 ## Unpack 'npcupg' firmware

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ versions are currently supported:
   * Version 13.x.x.x
   * Version 14.x.x.x
   * Version 22.x.x.x
+  * Version 23.x.x.x
 
     $ ./gm_app_fw.py -f ../npcupg_14.00.00.75.bin -v
     fw_ver : 14.00.00.75

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -227,7 +227,8 @@ class GMAppFirmware(object):
             # default is 14.0.0.75
             version = B4(75, 0, 0, 14)
         else:
-            m = re.match(r'(14)\.(0+)\.(\d+)\.(\d+)', self.fw_version)
+            supported_versions = "|".join([str(v) for v in list(self.EXEC_SZ)])
+            m = re.match(r'('+supported_versions+')\.(0+)\.(\d+)\.(\d+)', self.fw_version)
             if not m:
                 raise RuntimeError("%s: incorrect version" % self.fw_version)
             v1 = int(m.group(1))

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -211,7 +211,6 @@ class GMAppFirmware(object):
         self.md5 = hashlib.md5()
         fw_blob = self.fw_jffs + self.fw_exec
         self.md5.update(fw_blob)
-        self.calc_fw_signature()
         self.pack_header()
         print("Calculated fw_sig: %s" %
               binascii.b2a_hex(self.fw_sig))
@@ -224,14 +223,9 @@ class GMAppFirmware(object):
             fo.write(fw_blob)
 
     def pack_header(self):
-        self.hdr = GMAppFwHDR()
-        self.hdr.z00 = 0
-        self.hdr.jffs_sz = len(self.fw_jffs)
-        self.hdr.exec_sz = len(self.fw_exec)
-        self.hdr.csum = self.fw_sig
         if self.fw_version is None:
             # default is 14.0.0.75
-            self.hdr.fw_ver = B4(75, 0, 0, 14)
+            version = B4(75, 0, 0, 14)
         else:
             m = re.match(r'(14)\.(0+)\.(\d+)\.(\d+)', self.fw_version)
             if not m:
@@ -240,7 +234,14 @@ class GMAppFirmware(object):
             v2 = int(m.group(2))
             v3 = int(m.group(3))
             v4 = int(m.group(4))
-            self.hdr.fw_ver = B4(v4, v3, v2, v1)
+            version = B4(v4, v3, v2, v1)
+        self.hdr = GMAppFwHDR()
+        self.hdr.fw_ver = version
+        self.hdr.z00 = 0
+        self.hdr.jffs_sz = len(self.fw_jffs)
+        self.hdr.exec_sz = len(self.fw_exec)
+        self.calc_fw_signature()
+        self.hdr.csum = self.fw_sig
         print("Build FW version {3}.{2}.{1}.{0}".format(*(self.hdr.fw_ver)))
 
 

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -35,14 +35,16 @@ class GMAppFirmware(object):
     DES_KEY = {
        13 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\x82",  # specific for 13.0.0.x
        14 : "\x9C\xAE\x6A\x5A\xE1\xFC\xB0\x88",  # specific for 14.0.0.x
-       22 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xa8"   # specific for 22.0.0.x
+       22 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xa8",  # specific for 22.0.0.x
+       23 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xeb"   # specific for 23.0.0.x
     }
 
     EXEC_SZ = {
        13 : 0x19c7,
        14 : 0x1b21,
        21 : 0x1ad5,
-       22 : 0x18c7
+       22 : 0x18c7,
+       23 : 0x18c7
     }
 
 

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -23,7 +23,7 @@ class GMAppFwHDR(ctypes.Structure):
     _fields_ = [
         ('z00', ctypes.c_uint32),     # 0x00000000
         ('jffs_sz', ctypes.c_uint32),  # JFFS image size
-        ('exec_sz', ctypes.c_uint32),  # 0x1b21 - 14.0.0.x, 0x1ad5 - 21.0.0.x
+        ('exec_sz', ctypes.c_uint32),  # See EXEC_SZ list below
         ('csum', C16),
         ('fw_ver', B4),
     ]
@@ -33,6 +33,7 @@ GMAppFwHDR_p = ctypes.POINTER(GMAppFwHDR)
 class GMAppFirmware(object):
 
     DES_KEY = {
+       13 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\x82",  # specific for 13.0.0.x
        14 : "\x9C\xAE\x6A\x5A\xE1\xFC\xB0\x88",  # specific for 14.0.0.x
        22 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xa8"   # specific for 22.0.0.x
     }

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -261,6 +261,7 @@ def main():
     parser.add_argument('-V', '--version', dest='fw_version',
                         help='FW version, should match 14.0.N.N pattern')
     parser.add_argument('-d', '--debug', action='store_true')
+    parser.add_argument('-t', '--target', dest='target')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-v', '--verify', action='store_true')
     group.add_argument('-u', '--unpack', action='store_true')
@@ -282,7 +283,10 @@ def main():
     elif args.unpack:
         fw.do_unpack(args.out_fn, args.exec_fn)
     elif args.mount:
-        fw.do_mount()
+        if args.target:
+            fw.do_mount(mpoint=args.target)
+        else:
+            fw.do_mount()
     elif args.pack:
         fw.do_pack(args.jffs_image, args.exec_fn)
     else:

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -37,6 +37,13 @@ class GMAppFirmware(object):
        22 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xa8"   # specific for 22.0.0.x
     }
 
+    EXEC_SZ = {
+       13 : 0x19c7,
+       14 : 0x1b21,
+       21 : 0x1ad5,
+       22 : 0x18c7
+    }
+
 
     def __init__(self, firmware_fn, offset=0, verbose=False, fw_version=None):
         self.fw_version = fw_version  # used in do_pack()
@@ -63,11 +70,7 @@ class GMAppFirmware(object):
             self.h_buf = fi.read(0x20)
             hdr_a = ctypes.cast(ctypes.c_char_p(self.h_buf), GMAppFwHDR_p)
             self.hdr = hdr_a[0]
-            # 13 - 0x19c7
-            # 14 - 0x1b21
-            # 21 - 0x1ad5
-            # 22 - 0x18c7
-            assert self.hdr.exec_sz in (0x19c7, 0x1b21, 0x1ad5, 0x18c7), \
+            assert self.hdr.exec_sz in self.EXEC_SZ.values(), \
                 "Got unknown exec_sz = 0x%04x" % self.hdr.exec_sz
             fw_blob = fi.read()
             self.md5 = hashlib.md5()

--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -33,7 +33,8 @@ GMAppFwHDR_p = ctypes.POINTER(GMAppFwHDR)
 class GMAppFirmware(object):
 
     DES_KEY = {
-       14 : "\x9C\xAE\x6A\x5A\xE1\xFC\xB0\x88"   # specific for 14.0.0.x
+       14 : "\x9C\xAE\x6A\x5A\xE1\xFC\xB0\x88",  # specific for 14.0.0.x
+       22 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xa8"   # specific for 22.0.0.x
     }
 
 
@@ -65,7 +66,8 @@ class GMAppFirmware(object):
             # 13 - 0x19c7
             # 14 - 0x1b21
             # 21 - 0x1ad5
-            assert self.hdr.exec_sz in (0x19c7, 0x1b21, 0x1ad5), \
+            # 22 - 0x18c7
+            assert self.hdr.exec_sz in (0x19c7, 0x1b21, 0x1ad5, 0x18c7), \
                 "Got unknown exec_sz = 0x%04x" % self.hdr.exec_sz
             fw_blob = fi.read()
             self.md5 = hashlib.md5()


### PR DESCRIPTION
Currently the script can only maintain the version starting with `14.x.x.x` because it lists only the DES key for building the signature for these versions.

Other versions are using different DES keys. This patch will
* add support to be able to handle different versions with different keys
* add support for version `22.x.x.x` and add new DES key for this version
