### PR TITLE
Add key for firmware version 21.xx.xx.xx

### DIFF
--- a/gm_app_fw.py
+++ b/gm_app_fw.py
@@ -35,6 +35,7 @@ class GMAppFirmware(object):
     DES_KEY = {
        13 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\x82",  # specific for 13.0.0.x
        14 : "\x9C\xAE\x6A\x5A\xE1\xFC\xB0\x88",  # specific for 14.0.0.x
+       21 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\x98",  # specific for 21.0.0.x
        22 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xa8",  # specific for 22.0.0.x
        23 : "\x9c\xae\x6a\x5a\xe1\xfc\xb0\xeb"   # specific for 23.0.0.x
     }


### PR DESCRIPTION
This patch will add the key for 21.xx.xx.xx firmwares as suggested in #6.
